### PR TITLE
[bugfix] OPTIONS request lead to 500 server error

### DIFF
--- a/mashapeanalytics/middleware/django_middleware.py
+++ b/mashapeanalytics/middleware/django_middleware.py
@@ -67,7 +67,7 @@ class DjangoMiddleware(object):
     requestQueryString = [{'name': name, 'value': (value[0] if len(value) > 0 else None)} for name, value in parse_qs(request.META.get('QUERY_STRING', '')).items()]
 
     r = request.META.get('galileo.request')
-    requestContentSize = r.content_length or 0
+    requestContentSize = r.content_length or 0 if r else 0
 
     responseHeaders = [{'name': header, 'value': value[-1]} for (header, value) in response._headers.items()]
     responseHeadersSize = self.response_header_size(response)


### PR DESCRIPTION
Basically, it might happen that the `request` object passed to the
django middleware is `None`. That's the case when an `OPTIONS` request
is sent to the server for instance.

Using such a verb is a common use case when performing Cross Origin
Resource Sharing. The spec specifies that web browsers should
"preflight" the `GET/POST/PATCH/PUT/DELETE` request they're about to
perform using the `OPTIONS` verb ([more information here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)).

On line 70 in `mashapeanalytics/middleware/django_middleware.py`, when
fetching `r.content_length`, an exception was thrown when `r` was
`None`. Now what happens is that we check that `r` isn't `None` before
calling `r.content_length`. If `r` is `None` we simply assume that the
content length of the input request is `0`.
